### PR TITLE
Claude/prepare netto v0.2.0a2

### DIFF
--- a/netto/data_loader.py
+++ b/netto/data_loader.py
@@ -304,16 +304,7 @@ def load_all_pension_factors() -> Dict[int, float]:
 
 
 # Load all data at module import time and expose as module-level variables
-# These match the old const.py variable names for backward compatibility
 tax_curve = load_all_tax_curves()
 social_security_curve = load_all_social_security()
 soli_curve = load_all_soli()
 correction_factor_pensions = load_all_pension_factors()
-
-
-# Expose private names for backward compatibility with existing code
-# that imports from const.py with leading underscores
-__tax_curve = tax_curve
-__social_security_curve = social_security_curve
-__soli_curve = soli_curve
-__correction_factor_pensions = correction_factor_pensions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netto"
-version = "0.2.0a1"
+version = "0.2.0a2"
 authors = [
   { name="Martin Klein", email="hi@martinklein.co" },
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,7 @@
 black
 isort
+pytest
+pytest-cov
 sphinx
 myst-parser
 build

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,52 +1,55 @@
-import unittest
+import pytest
 
 from netto.config import TaxConfig
 
 
-class TestConfig(unittest.TestCase):
-    def test_taxconfig_defaults(self):
-        """Test that TaxConfig uses correct default values"""
-        config = TaxConfig()
-        self.assertEqual(config.year, 2022)
-        self.assertFalse(config.has_children)
-        self.assertFalse(config.is_married)
-        self.assertEqual(config.extra_health_insurance, 0.014)
-        self.assertEqual(config.church_tax, 0.09)
+def test_taxconfig_defaults():
+    """Test that TaxConfig uses correct default values"""
+    config = TaxConfig()
+    assert config.year == 2022
+    assert config.has_children is False
+    assert config.is_married is False
+    assert config.extra_health_insurance == 0.014
+    assert config.church_tax == 0.09
 
-    def test_taxconfig_custom_values(self):
-        """Test creating TaxConfig with custom values"""
-        config = TaxConfig(
-            year=2025,
-            has_children=True,
-            is_married=True,
-            extra_health_insurance=0.02,
-            church_tax=0.08
-        )
-        self.assertEqual(config.year, 2025)
-        self.assertTrue(config.has_children)
-        self.assertTrue(config.is_married)
-        self.assertEqual(config.extra_health_insurance, 0.02)
-        self.assertEqual(config.church_tax, 0.08)
 
-    def test_taxconfig_validation_year_range(self):
-        """Test that year validation works"""
-        with self.assertRaises(ValueError):
-            TaxConfig(year=2017)  # Too early
-        with self.assertRaises(ValueError):
-            TaxConfig(year=2026)  # Too late
+def test_taxconfig_custom_values():
+    """Test creating TaxConfig with custom values"""
+    config = TaxConfig(
+        year=2025,
+        has_children=True,
+        is_married=True,
+        extra_health_insurance=0.02,
+        church_tax=0.08
+    )
+    assert config.year == 2025
+    assert config.has_children is True
+    assert config.is_married is True
+    assert config.extra_health_insurance == 0.02
+    assert config.church_tax == 0.08
 
-    def test_taxconfig_validation_negative_rates(self):
-        """Test that negative rates are rejected"""
-        with self.assertRaises(ValueError):
-            TaxConfig(extra_health_insurance=-0.01)
-        with self.assertRaises(ValueError):
-            TaxConfig(church_tax=-0.01)
 
-    def test_taxconfig_validation_type_errors(self):
-        """Test that type validation works"""
-        with self.assertRaises(TypeError):
-            TaxConfig(year="2022")  # String instead of int
-        with self.assertRaises(TypeError):
-            TaxConfig(has_children="True")  # String instead of bool
-        with self.assertRaises(TypeError):
-            TaxConfig(is_married=1)  # Int instead of bool
+def test_taxconfig_validation_year_range():
+    """Test that year validation works"""
+    with pytest.raises(ValueError):
+        TaxConfig(year=2017)  # Too early
+    with pytest.raises(ValueError):
+        TaxConfig(year=2026)  # Too late
+
+
+def test_taxconfig_validation_negative_rates():
+    """Test that negative rates are rejected"""
+    with pytest.raises(ValueError):
+        TaxConfig(extra_health_insurance=-0.01)
+    with pytest.raises(ValueError):
+        TaxConfig(church_tax=-0.01)
+
+
+def test_taxconfig_validation_type_errors():
+    """Test that type validation works"""
+    with pytest.raises(TypeError):
+        TaxConfig(year="2022")  # String instead of int
+    with pytest.raises(TypeError):
+        TaxConfig(has_children="True")  # String instead of bool
+    with pytest.raises(TypeError):
+        TaxConfig(is_married=1)  # Int instead of bool

--- a/test/test_data_loader.py
+++ b/test/test_data_loader.py
@@ -382,21 +382,3 @@ def test_pension_factor_value_2022():
     factor_2022 = load_pension_factor(2022)
 
     assert factor_2022 == 0.88
-
-
-# Test backward compatibility with old const.py names
-
-
-def test_backward_compatibility_imports():
-    """Test that old const.py variable names are available"""
-    from netto.data_loader import (
-        __tax_curve,
-        __social_security_curve,
-        __soli_curve,
-        __correction_factor_pensions
-    )
-
-    assert __tax_curve == tax_curve
-    assert __social_security_curve == social_security_curve
-    assert __soli_curve == soli_curve
-    assert __correction_factor_pensions == correction_factor_pensions

--- a/test/test_data_loader.py
+++ b/test/test_data_loader.py
@@ -1,0 +1,402 @@
+import pytest
+from pathlib import Path
+from pydantic import ValidationError
+
+from netto.data_loader import (
+    TaxBracket,
+    TaxCurve,
+    SocialSecurityEntry,
+    SocialSecurity,
+    SoliCurve,
+    PensionFactor,
+    load_tax_curve,
+    load_social_security,
+    load_soli,
+    load_pension_factor,
+    load_all_tax_curves,
+    load_all_social_security,
+    load_all_soli,
+    load_all_pension_factors,
+    tax_curve,
+    social_security_curve,
+    soli_curve,
+    correction_factor_pensions,
+)
+
+
+# Tests for Pydantic Models
+
+
+def test_tax_bracket_valid():
+    """Test creating a valid TaxBracket"""
+    bracket = TaxBracket(step=10000, rate=0.14, const=[100, 200])
+    assert bracket.step == 10000
+    assert bracket.rate == 0.14
+    assert bracket.const == [100, 200]
+
+
+def test_tax_bracket_no_const():
+    """Test creating TaxBracket without const"""
+    bracket = TaxBracket(step=10000, rate=0.0)
+    assert bracket.step == 10000
+    assert bracket.rate == 0.0
+    assert bracket.const is None
+
+
+def test_tax_bracket_invalid_step():
+    """Test that TaxBracket rejects invalid step values"""
+    with pytest.raises(ValidationError):
+        TaxBracket(step=0, rate=0.14)  # step must be > 0
+    with pytest.raises(ValidationError):
+        TaxBracket(step=-100, rate=0.14)  # negative not allowed
+
+
+def test_tax_bracket_invalid_rate():
+    """Test that TaxBracket rejects invalid rate values"""
+    with pytest.raises(ValidationError):
+        TaxBracket(step=10000, rate=-0.1)  # negative not allowed
+    with pytest.raises(ValidationError):
+        TaxBracket(step=10000, rate=1.5)  # > 1 not allowed
+
+
+def test_tax_bracket_empty_const():
+    """Test that TaxBracket rejects empty const array"""
+    with pytest.raises(ValidationError):
+        TaxBracket(step=10000, rate=0.14, const=[])
+
+
+def test_tax_curve_valid():
+    """Test creating a valid TaxCurve"""
+    curve = TaxCurve(
+        year=2022,
+        brackets={
+            "0": TaxBracket(step=10347, rate=0.0),
+            "1": TaxBracket(step=14927, rate=0.14, const=[995.21, 1400]),
+            "2": TaxBracket(step=58597, rate=0.2397, const=[208.85, 2397, 950.96]),
+            "3": TaxBracket(step=277826, rate=0.42, const=[0.42, 9336.45]),
+        }
+    )
+    assert curve.year == 2022
+    assert len(curve.brackets) == 4
+
+
+def test_tax_curve_invalid_brackets():
+    """Test that TaxCurve requires exactly 4 brackets"""
+    with pytest.raises(ValidationError):
+        TaxCurve(
+            year=2022,
+            brackets={
+                "0": TaxBracket(step=10000, rate=0.0),
+                "1": TaxBracket(step=20000, rate=0.14),
+            }
+        )
+
+
+def test_tax_curve_invalid_year():
+    """Test that TaxCurve validates year range"""
+    with pytest.raises(ValidationError):
+        TaxCurve(
+            year=2015,  # Too early
+            brackets={
+                "0": TaxBracket(step=10000, rate=0.0),
+                "1": TaxBracket(step=20000, rate=0.14),
+                "2": TaxBracket(step=30000, rate=0.24),
+                "3": TaxBracket(step=40000, rate=0.42),
+            }
+        )
+
+
+def test_social_security_entry_valid():
+    """Test creating a valid SocialSecurityEntry"""
+    entry = SocialSecurityEntry(limit=84600, rate=0.093)
+    assert entry.limit == 84600
+    assert entry.rate == 0.093
+    assert entry.extra is None
+
+
+def test_social_security_entry_with_extra():
+    """Test creating SocialSecurityEntry with extra rate"""
+    entry = SocialSecurityEntry(limit=58050, rate=0.073, extra=0.0035)
+    assert entry.limit == 58050
+    assert entry.rate == 0.073
+    assert entry.extra == 0.0035
+
+
+def test_social_security_entry_invalid_limit():
+    """Test that SocialSecurityEntry validates limit"""
+    with pytest.raises(ValidationError):
+        SocialSecurityEntry(limit=0, rate=0.093)  # Must be > 0
+    with pytest.raises(ValidationError):
+        SocialSecurityEntry(limit=-1000, rate=0.093)  # Negative not allowed
+
+
+def test_social_security_valid():
+    """Test creating a valid SocialSecurity"""
+    ss = SocialSecurity(
+        year=2022,
+        pension=SocialSecurityEntry(limit=84600, rate=0.093),
+        unemployment=SocialSecurityEntry(limit=84600, rate=0.012),
+        health=SocialSecurityEntry(limit=58050, rate=0.073, extra=0.007),
+        nursing=SocialSecurityEntry(limit=58050, rate=0.01525, extra=0.0035)
+    )
+    assert ss.year == 2022
+    assert ss.pension.limit == 84600
+    assert ss.health.extra == 0.007
+
+
+def test_soli_curve_valid():
+    """Test creating a valid SoliCurve"""
+    soli = SoliCurve(
+        year=2022,
+        start_taxable_income=16956,
+        start_fraction=0.119,
+        end_rate=0.055
+    )
+    assert soli.year == 2022
+    assert soli.start_taxable_income == 16956
+    assert soli.start_fraction == 0.119
+    assert soli.end_rate == 0.055
+
+
+def test_pension_factor_valid():
+    """Test creating a valid PensionFactor"""
+    factor = PensionFactor(year=2022, factor=0.88)
+    assert factor.year == 2022
+    assert factor.factor == 0.88
+
+
+def test_pension_factor_invalid_factor():
+    """Test that PensionFactor validates factor range"""
+    with pytest.raises(ValidationError):
+        PensionFactor(year=2022, factor=-0.1)  # Negative not allowed
+    with pytest.raises(ValidationError):
+        PensionFactor(year=2022, factor=1.5)  # > 1 not allowed
+
+
+# Tests for individual load functions
+
+
+@pytest.mark.parametrize("year", [2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025])
+def test_load_tax_curve(year):
+    """Test loading tax curve for available years"""
+    curve = load_tax_curve(year)
+    assert isinstance(curve, dict)
+    assert len(curve) == 4
+    assert all(k in [0, 1, 2, 3] for k in curve.keys())
+    assert all("step" in v and "rate" in v for v in curve.values())
+
+
+def test_load_tax_curve_missing_year():
+    """Test that loading tax curve for missing year raises FileNotFoundError"""
+    with pytest.raises(FileNotFoundError):
+        load_tax_curve(2030)
+
+
+@pytest.mark.parametrize("year", [2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025])
+def test_load_social_security(year):
+    """Test loading social security for available years"""
+    ss = load_social_security(year)
+    assert isinstance(ss, dict)
+    assert "pension" in ss
+    assert "unemployment" in ss
+    assert "health" in ss
+    assert "nursing" in ss
+
+
+def test_load_social_security_not_implemented():
+    """Test that loading social security for 2026+ raises NotImplementedError"""
+    with pytest.raises(NotImplementedError):
+        load_social_security(2026)
+
+
+def test_load_social_security_missing_year():
+    """Test that loading social security for missing year raises FileNotFoundError"""
+    with pytest.raises(FileNotFoundError):
+        load_social_security(2015)
+
+
+@pytest.mark.parametrize("year", [2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025])
+def test_load_soli(year):
+    """Test loading solidarity tax data for available years"""
+    soli = load_soli(year)
+    assert isinstance(soli, dict)
+    assert "start_taxable_income" in soli
+    assert "start_fraction" in soli
+    assert "end_rate" in soli
+
+
+def test_load_soli_missing_year():
+    """Test that loading soli for missing year raises FileNotFoundError"""
+    with pytest.raises(FileNotFoundError):
+        load_soli(2030)
+
+
+@pytest.mark.parametrize("year", [2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025])
+def test_load_pension_factor(year):
+    """Test loading pension factor for available years"""
+    factor = load_pension_factor(year)
+    assert isinstance(factor, float)
+    assert 0 <= factor <= 1
+
+
+def test_load_pension_factor_missing_year():
+    """Test that loading pension factor for missing year raises FileNotFoundError"""
+    with pytest.raises(FileNotFoundError):
+        load_pension_factor(2030)
+
+
+# Tests for bulk load functions
+
+
+def test_load_all_tax_curves():
+    """Test loading all tax curves"""
+    curves = load_all_tax_curves()
+    assert isinstance(curves, dict)
+    assert len(curves) >= 8  # At least 2018-2025
+    for year, curve in curves.items():
+        assert isinstance(year, int)
+        assert isinstance(curve, dict)
+        assert len(curve) == 4
+
+
+def test_load_all_social_security():
+    """Test loading all social security data"""
+    ss_data = load_all_social_security()
+    assert isinstance(ss_data, dict)
+    assert len(ss_data) >= 8  # At least 2018-2025
+    # Check for 2026 NotImplementedError marker
+    assert 2026 in ss_data
+    assert ss_data[2026] == NotImplementedError
+
+
+def test_load_all_soli():
+    """Test loading all solidarity tax data"""
+    soli_data = load_all_soli()
+    assert isinstance(soli_data, dict)
+    assert len(soli_data) >= 8  # At least 2018-2025
+    for year, soli in soli_data.items():
+        assert isinstance(year, int)
+        assert isinstance(soli, dict)
+
+
+def test_load_all_pension_factors():
+    """Test loading all pension factors"""
+    factors = load_all_pension_factors()
+    assert isinstance(factors, dict)
+    assert len(factors) >= 8  # At least 2018-2025
+    for year, factor in factors.items():
+        assert isinstance(year, int)
+        assert isinstance(factor, float)
+        assert 0 <= factor <= 1
+
+
+# Tests for module-level variables
+
+
+def test_module_tax_curve():
+    """Test that tax_curve is loaded at module level"""
+    assert isinstance(tax_curve, dict)
+    assert len(tax_curve) >= 8
+    assert 2022 in tax_curve
+    assert len(tax_curve[2022]) == 4
+
+
+def test_module_social_security_curve():
+    """Test that social_security_curve is loaded at module level"""
+    assert isinstance(social_security_curve, dict)
+    assert len(social_security_curve) >= 8
+    assert 2022 in social_security_curve
+    assert "pension" in social_security_curve[2022]
+
+
+def test_module_soli_curve():
+    """Test that soli_curve is loaded at module level"""
+    assert isinstance(soli_curve, dict)
+    assert len(soli_curve) >= 8
+    assert 2022 in soli_curve
+    assert "start_taxable_income" in soli_curve[2022]
+
+
+def test_module_correction_factor_pensions():
+    """Test that correction_factor_pensions is loaded at module level"""
+    assert isinstance(correction_factor_pensions, dict)
+    assert len(correction_factor_pensions) >= 8
+    assert 2022 in correction_factor_pensions
+    assert isinstance(correction_factor_pensions[2022], float)
+
+
+# Integration tests
+
+
+def test_tax_curve_structure_2022():
+    """Test that 2022 tax curve has expected structure"""
+    curve_2022 = load_tax_curve(2022)
+
+    # Bracket 0: Basic allowance
+    assert curve_2022[0]["step"] == 10347
+    assert curve_2022[0]["rate"] == 0.14
+
+    # Bracket 1: Progressive zone 1
+    assert curve_2022[1]["step"] == 14926
+    assert curve_2022[1]["rate"] == 0.2397
+    assert curve_2022[1]["const"] is not None
+
+    # Bracket 2: Progressive zone 2
+    assert curve_2022[2]["step"] == 58596
+    assert curve_2022[2]["rate"] == 0.42
+    assert curve_2022[2]["const"] is not None
+
+    # Bracket 3: Top rate
+    assert curve_2022[3]["step"] == 277826
+    assert curve_2022[3]["rate"] == 0.45
+
+
+def test_social_security_structure_2022():
+    """Test that 2022 social security has expected structure"""
+    ss_2022 = load_social_security(2022)
+
+    # Pension insurance
+    assert ss_2022["pension"]["limit"] == 84600
+    assert ss_2022["pension"]["rate"] == 0.093
+
+    # Health insurance
+    assert ss_2022["health"]["limit"] == 58050
+    assert ss_2022["health"]["rate"] == 0.073
+
+    # Nursing insurance
+    assert ss_2022["nursing"]["limit"] == 58050
+    assert ss_2022["nursing"]["rate"] == 0.01525
+
+
+def test_soli_structure_2022():
+    """Test that 2022 soli has expected structure"""
+    soli_2022 = load_soli(2022)
+
+    assert soli_2022["start_taxable_income"] == 16956
+    assert soli_2022["start_fraction"] == 0.119
+    assert soli_2022["end_rate"] == 0.055
+
+
+def test_pension_factor_value_2022():
+    """Test that 2022 pension factor has expected value"""
+    factor_2022 = load_pension_factor(2022)
+
+    assert factor_2022 == 0.88
+
+
+# Test backward compatibility with old const.py names
+
+
+def test_backward_compatibility_imports():
+    """Test that old const.py variable names are available"""
+    from netto.data_loader import (
+        __tax_curve,
+        __social_security_curve,
+        __soli_curve,
+        __correction_factor_pensions
+    )
+
+    assert __tax_curve == tax_curve
+    assert __social_security_curve == social_security_curve
+    assert __soli_curve == soli_curve
+    assert __correction_factor_pensions == correction_factor_pensions

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 from io import StringIO
 from unittest.mock import patch
 
@@ -6,57 +6,100 @@ from netto.config import TaxConfig
 import netto.main as main
 
 
-class TestMain(unittest.TestCase):
-    def setUp(self):
-        # Create default config for tests
-        self.default_config = TaxConfig(
-            extra_health_insurance=0.014,
-            church_tax=0.09,
-            has_children=False
-        )
+@pytest.fixture
+def default_config():
+    """Fixture providing default config for tests"""
+    return TaxConfig(
+        extra_health_insurance=0.014,
+        church_tax=0.09,
+        has_children=False
+    )
 
-    def tearDown(self):
-        pass
 
-    def test_for_valid_main(self):
-        self.assertEqual(main.calc_netto(0, config=self.default_config), 0)
-        self.assertAlmostEqual(main.calc_netto(30000, config=self.default_config), 20554.38, delta=1)
-        self.assertAlmostEqual(main.calc_netto(60000, config=self.default_config), 35796.68, delta=1)
-        self.assertAlmostEqual(main.calc_netto(90000, config=self.default_config), 49956.92, delta=1)
-        self.assertAlmostEqual(main.calc_netto(120000, config=self.default_config), 64965.08, delta=1)
+@pytest.fixture
+def alternate_config():
+    """Fixture providing alternate config for tests"""
+    return TaxConfig(
+        extra_health_insurance=0.015,
+        church_tax=0.0,
+        has_children=True
+    )
 
-    def test_for_valid_main_second_config(self):
-        config = TaxConfig(
-            extra_health_insurance=0.015,
-            church_tax=0.0,
-            has_children=True
-        )
-        self.assertAlmostEqual(main.calc_netto(30000, config=config), 20894.58, delta=1)
-        self.assertAlmostEqual(main.calc_netto(60000, config=config), 36909.71, delta=1)
-        self.assertAlmostEqual(main.calc_netto(90000, config=config), 52091.39, delta=1)
-        self.assertAlmostEqual(main.calc_netto(120000, config=config), 68238.23, delta=1)
 
-    def test_for_valid_inverse_netto(self):
-        config = TaxConfig(
-            extra_health_insurance=0.015,
-            church_tax=0.0,
-            has_children=True
-        )
-        self.assertEqual(main.calc_inverse_netto(main.calc_netto(10000, config=config), config=config), 10000)
-        self.assertAlmostEqual(main.calc_inverse_netto(20894.58, config=config), 30000, delta=1)
-        self.assertAlmostEqual(main.calc_inverse_netto(36909.71, config=config), 60000, delta=1)
-        self.assertAlmostEqual(main.calc_inverse_netto(52091.39, config=config), 90000, delta=1)
-        self.assertAlmostEqual(main.calc_inverse_netto(68238.23, config=config), 120000, delta=1)
+@pytest.mark.parametrize("salary,expected", [
+    (0, 0),
+    (30000, 20554.38),
+    (60000, 35796.68),
+    (90000, 49956.92),
+    (120000, 64965.08),
+])
+def test_calc_netto_with_default_config(salary, expected, default_config):
+    """Test calc_netto with various salaries using default config"""
+    result = main.calc_netto(salary, config=default_config)
+    assert abs(result - expected) < 1
 
-    @patch("sys.stdout", new_callable=StringIO)
-    def test_verbose_print(self, mock_stdout):
-        main.calc_netto(0, verbose=True, config=self.default_config)
-        actual_output = mock_stdout.getvalue().strip()
-        expected_output = (
-            "Yearly Evaluation:\n"
-            + f"Income Tax:      {0.0:>12}\n"
-            + f"Soli:            {0.0:>12}\n"
-            + f"Church Tax:      {0.0:>12}\n"
-            + f"Social Security: {0.0:>12}"
-        )
-        self.assertEqual(actual_output, expected_output)
+
+@pytest.mark.parametrize("salary,expected", [
+    (30000, 20894.58),
+    (60000, 36909.71),
+    (90000, 52091.39),
+    (120000, 68238.23),
+])
+def test_calc_netto_with_alternate_config(salary, expected, alternate_config):
+    """Test calc_netto with alternate config (no church tax, with children)"""
+    result = main.calc_netto(salary, config=alternate_config)
+    assert abs(result - expected) < 1
+
+
+@pytest.mark.parametrize("desired_netto,expected_gross", [
+    (20894.58, 30000),
+    (36909.71, 60000),
+    (52091.39, 90000),
+    (68238.23, 120000),
+])
+def test_calc_inverse_netto(desired_netto, expected_gross, alternate_config):
+    """Test inverse netto calculation"""
+    result = main.calc_inverse_netto(desired_netto, config=alternate_config)
+    assert abs(result - expected_gross) <= 1
+
+
+def test_calc_inverse_netto_roundtrip(alternate_config):
+    """Test that calc_inverse_netto and calc_netto are inverses"""
+    salary = 10000
+    netto = main.calc_netto(salary, config=alternate_config)
+    gross = main.calc_inverse_netto(netto, config=alternate_config)
+    assert gross == salary
+
+
+@patch("sys.stdout", new_callable=StringIO)
+def test_verbose_print(mock_stdout, default_config):
+    """Test that verbose mode prints expected output"""
+    main.calc_netto(0, verbose=True, config=default_config)
+    actual_output = mock_stdout.getvalue().strip()
+    expected_output = (
+        "Yearly Evaluation:\n"
+        + f"Income Tax:      {0.0:>12}\n"
+        + f"Soli:            {0.0:>12}\n"
+        + f"Church Tax:      {0.0:>12}\n"
+        + f"Social Security: {0.0:>12}"
+    )
+    assert actual_output == expected_output
+
+
+def test_calc_netto_with_default_none_config():
+    """Test that calc_netto works when config=None (uses default TaxConfig)"""
+    result = main.calc_netto(30000)
+    # Should use default TaxConfig (year=2022, etc.)
+    assert isinstance(result, float)
+    assert result > 0
+
+
+def test_calc_inverse_netto_with_default_none_config():
+    """Test that calc_inverse_netto works when config=None (uses default TaxConfig)"""
+    # Use a value that we know works well with Newton's method
+    result = main.calc_inverse_netto(30000)
+    # Should use default TaxConfig
+    assert isinstance(result, (int, float))
+    assert result > 0
+    # Verify the result makes sense (gross should be higher than net)
+    assert result > 30000

--- a/test/test_social_security.py
+++ b/test/test_social_security.py
@@ -1,94 +1,195 @@
-import unittest
+import pytest
 
 from netto.config import TaxConfig
 import netto.social_security as social_security
 
 
-class TestSocialSecurity(unittest.TestCase):
-    def setUp(self):
-        # Create default config for tests
-        self.default_config = TaxConfig(
-            extra_health_insurance=0.014,
-            church_tax=0.09,
-            has_children=False
-        )
+@pytest.fixture
+def default_config():
+    """Fixture providing default config for tests"""
+    return TaxConfig(
+        extra_health_insurance=0.014,
+        church_tax=0.09,
+        has_children=False
+    )
 
-    def tearDown(self):
-        pass
 
-    def test_get_rate_pension(self):
-        self.assertEqual(social_security.get_rate_pension(0, self.default_config), 0)
-        self.assertEqual(social_security.get_rate_pension(10000, self.default_config), 0.093)
-        self.assertEqual(social_security.get_rate_pension(84600, self.default_config), 0.093)
-        self.assertEqual(social_security.get_rate_pension(84601, self.default_config), 0)
-        self.assertEqual(social_security.get_rate_pension(100000, self.default_config), 0)
+@pytest.mark.parametrize("salary,expected", [
+    (0, 0),
+    (10000, 0.093),
+    (84600, 0.093),
+    (84601, 0),
+    (100000, 0),
+])
+def test_get_rate_pension(salary, expected, default_config):
+    """Test pension rate calculation"""
+    result = social_security.get_rate_pension(salary, default_config)
+    assert result == expected
 
-    def test_get_rate_health(self):
-        self.assertEqual(social_security.get_rate_health(0, self.default_config), 0)
-        self.assertEqual(social_security.get_rate_health(10000, self.default_config), 0.08)
-        self.assertEqual(social_security.get_rate_health(58050, self.default_config), 0.08)
-        self.assertEqual(social_security.get_rate_health(58051, self.default_config), 0)
-        self.assertEqual(social_security.get_rate_health(100000, self.default_config), 0)
 
-    def test_calc_insurance_pension(self):
-        self.assertEqual(social_security.calc_insurance_pension(0, self.default_config), 0)
-        self.assertEqual(social_security.calc_insurance_pension(10000, self.default_config), 0.093 * 10000)
-        self.assertEqual(social_security.calc_insurance_pension(84600, self.default_config), 0.093 * 84600)
-        self.assertEqual(social_security.calc_insurance_pension(84601, self.default_config), 0.093 * 84600)
-        self.assertEqual(social_security.calc_insurance_pension(100000, self.default_config), 0.093 * 84600)
+@pytest.mark.parametrize("salary,expected", [
+    (0, 0),
+    (10000, 0.08),
+    (58050, 0.08),
+    (58051, 0),
+    (100000, 0),
+])
+def test_get_rate_health(salary, expected, default_config):
+    """Test health insurance rate calculation"""
+    result = social_security.get_rate_health(salary, default_config)
+    assert result == expected
 
-    def test_calc_insurance_health(self):
-        self.assertEqual(social_security.calc_insurance_health(0, self.default_config), 0)
-        self.assertEqual(social_security.calc_insurance_health(10000, self.default_config), 0.08 * 10000)
-        self.assertEqual(social_security.calc_insurance_health(58050, self.default_config), 0.08 * 58050)
-        self.assertEqual(social_security.calc_insurance_health(58051, self.default_config), 0.08 * 58050)
-        self.assertEqual(social_security.calc_insurance_health(100000, self.default_config), 0.08 * 58050)
 
-    def test_calc_deductable_social_security(self):
-        self.assertEqual(social_security.calc_deductible_social_security(0, self.default_config), 0)
-        self.assertEqual(
-            social_security.calc_deductible_social_security(30000, self.default_config),
-            2456 + 2310 + 563,  # https://www.lohn-info.de/vorsorgepauschale.html
-        )
+@pytest.mark.parametrize("salary,expected", [
+    (0, 0),
+    (10000, 0.093 * 10000),
+    (84600, 0.093 * 84600),
+    (84601, 0.093 * 84600),
+    (100000, 0.093 * 84600),
+])
+def test_calc_insurance_pension(salary, expected, default_config):
+    """Test pension insurance calculation"""
+    result = social_security.calc_insurance_pension(salary, default_config)
+    assert result == expected
 
-    def test_sameness_of_calc_social_security(self):
-        for salary in range(0, 100001, 10000):
-            self.assertEqual(
-                social_security.calc_social_security(salary, self.default_config),
-                social_security.calc_social_security_by_integration(salary, self.default_config),
-            )
 
-    def test_sameness_of_calc_social_security_different_config(self):
-        config = TaxConfig(
-            extra_health_insurance=0.015,
-            has_children=True
-        )
-        for salary in range(0, 100001, 10000):
-            self.assertEqual(
-                social_security.calc_social_security(salary, config),
-                social_security.calc_social_security_by_integration(salary, config),
-            )
+@pytest.mark.parametrize("salary,expected", [
+    (0, 0),
+    (10000, 0.08 * 10000),
+    (58050, 0.08 * 58050),
+    (58051, 0.08 * 58050),
+    (100000, 0.08 * 58050),
+])
+def test_calc_insurance_health(salary, expected, default_config):
+    """Test health insurance calculation"""
+    result = social_security.calc_insurance_health(salary, default_config)
+    assert result == expected
 
-    def test_get_rate_health_different_config(self):
-        config = TaxConfig(extra_health_insurance=0.015)
-        self.assertEqual(social_security.get_rate_health(0, config), 0)
-        self.assertAlmostEqual(social_security.get_rate_health(10000, config), 0.0805)
-        self.assertAlmostEqual(social_security.get_rate_health(58050, config), 0.0805)
-        self.assertEqual(social_security.get_rate_health(58051, config), 0)
-        self.assertEqual(social_security.get_rate_health(100000, config), 0)
 
-    def test_get_rate_nursing(self):
-        config = TaxConfig(has_children=False)
-        self.assertEqual(social_security.get_rate_nursing(0, config), 0)
-        self.assertEqual(social_security.get_rate_nursing(10000, config), 0.01875)
-        self.assertEqual(social_security.get_rate_nursing(58050, config), 0.01875)
-        self.assertEqual(social_security.get_rate_nursing(58051, config), 0)
-        self.assertEqual(social_security.get_rate_nursing(100000, config), 0)
+def test_calc_deductible_social_security(default_config):
+    """Test deductible social security calculation"""
+    assert social_security.calc_deductible_social_security(0, default_config) == 0
+    # https://www.lohn-info.de/vorsorgepauschale.html
+    assert social_security.calc_deductible_social_security(30000, default_config) == 2456 + 2310 + 563
 
-    def test_get_rate_nursing_different_config(self):
-        config = TaxConfig(has_children=True)
-        self.assertEqual(social_security.get_rate_nursing(0, config), 0)
-        self.assertEqual(social_security.get_rate_nursing(10000, config), 0.01525)
-        self.assertEqual(social_security.get_rate_nursing(58050, config), 0.01525)
-        self.assertEqual(social_security.get_rate_nursing(58051, config), 0)
-        self.assertEqual(social_security.get_rate_nursing(100000, config), 0)
+
+@pytest.mark.parametrize("salary", [
+    0, 10000, 20000, 30000, 40000, 50000, 60000, 70000, 80000, 90000, 100000
+])
+def test_sameness_of_calc_social_security(salary, default_config):
+    """Test that both social security calculation methods give same results"""
+    result_direct = social_security.calc_social_security(salary, default_config)
+    result_integration = social_security.calc_social_security_by_integration(salary, default_config)
+    assert result_direct == result_integration
+
+
+@pytest.mark.parametrize("salary", [
+    0, 10000, 20000, 30000, 40000, 50000, 60000, 70000, 80000, 90000, 100000
+])
+def test_sameness_of_calc_social_security_different_config(salary):
+    """Test social security calculation with different config"""
+    config = TaxConfig(
+        extra_health_insurance=0.015,
+        has_children=True
+    )
+    result_direct = social_security.calc_social_security(salary, config)
+    result_integration = social_security.calc_social_security_by_integration(salary, config)
+    assert result_direct == result_integration
+
+
+@pytest.mark.parametrize("salary,expected", [
+    (0, 0),
+    (10000, 0.0805),
+    (58050, 0.0805),
+    (58051, 0),
+    (100000, 0),
+])
+def test_get_rate_health_different_config(salary, expected):
+    """Test health rate with different extra health insurance"""
+    config = TaxConfig(extra_health_insurance=0.015)
+    result = social_security.get_rate_health(salary, config)
+    assert abs(result - expected) < 0.0001
+
+
+@pytest.mark.parametrize("salary,expected", [
+    (0, 0),
+    (10000, 0.01875),
+    (58050, 0.01875),
+    (58051, 0),
+    (100000, 0),
+])
+def test_get_rate_nursing_no_children(salary, expected):
+    """Test nursing rate without children (includes extra rate)"""
+    config = TaxConfig(has_children=False)
+    result = social_security.get_rate_nursing(salary, config)
+    assert result == expected
+
+
+@pytest.mark.parametrize("salary,expected", [
+    (0, 0),
+    (10000, 0.01525),
+    (58050, 0.01525),
+    (58051, 0),
+    (100000, 0),
+])
+def test_get_rate_nursing_with_children(salary, expected):
+    """Test nursing rate with children (no extra rate)"""
+    config = TaxConfig(has_children=True)
+    result = social_security.get_rate_nursing(salary, config)
+    assert result == expected
+
+
+def test_get_rate_pension_with_default_none_config():
+    """Test that get_rate_pension works when config=None"""
+    result = social_security.get_rate_pension(50000)
+    assert isinstance(result, float)
+    assert result >= 0
+
+
+def test_get_rate_unemployment_with_default_none_config():
+    """Test that get_rate_unemployment works when config=None"""
+    result = social_security.get_rate_unemployment(50000)
+    assert isinstance(result, float)
+    assert result >= 0
+
+
+def test_get_rate_health_with_default_none_config():
+    """Test that get_rate_health works when config=None"""
+    result = social_security.get_rate_health(50000)
+    assert isinstance(result, float)
+    assert result >= 0
+
+
+def test_get_rate_nursing_with_default_none_config():
+    """Test that get_rate_nursing works when config=None"""
+    result = social_security.get_rate_nursing(50000)
+    assert isinstance(result, float)
+    assert result >= 0
+
+
+def test_calc_insurance_pension_with_default_none_config():
+    """Test that calc_insurance_pension works when config=None"""
+    result = social_security.calc_insurance_pension(50000)
+    assert isinstance(result, float)
+    assert result >= 0
+
+
+def test_calc_insurance_health_with_default_none_config():
+    """Test that calc_insurance_health works when config=None"""
+    result = social_security.calc_insurance_health(50000)
+    assert isinstance(result, float)
+    assert result >= 0
+
+
+def test_calc_social_security_with_default_none_config():
+    """Test that calc_social_security works when config=None"""
+    result = social_security.calc_social_security(50000)
+    assert isinstance(result, float)
+    assert result >= 0
+
+
+def test_calc_deductible_social_security_with_default_none_config():
+    """Test that calc_deductible_social_security works when config=None"""
+    result = social_security.calc_deductible_social_security(50000)
+    assert isinstance(result, (int, float))
+    assert result >= 0

--- a/test/test_taxes_income.py
+++ b/test/test_taxes_income.py
@@ -1,54 +1,78 @@
-import unittest
+import pytest
 
 from netto.config import TaxConfig
 import netto.taxes_income as taxes_income
 
 
-class TestTaxesIncome(unittest.TestCase):
-    def setUp(self):
-        # Create default config for tests
-        self.default_config = TaxConfig(
-            extra_health_insurance=0.014,
-            church_tax=0.09,
-            has_children=False
-        )
+@pytest.fixture
+def default_config():
+    """Fixture providing default config for tests"""
+    return TaxConfig(
+        extra_health_insurance=0.014,
+        church_tax=0.09,
+        has_children=False
+    )
 
-    def tearDown(self):
-        pass
 
-    def test_valid_get_marginal_tax_rate(self):
-        self.assertEqual(taxes_income.get_marginal_tax_rate(-1000, self.default_config), 0)
-        self.assertEqual(taxes_income.get_marginal_tax_rate(0, self.default_config), 0)
-        self.assertEqual(taxes_income.get_marginal_tax_rate(10346, self.default_config), 0)
-        self.assertEqual(taxes_income.get_marginal_tax_rate(10347, self.default_config), 0.14)
-        self.assertEqual(taxes_income.get_marginal_tax_rate(14926, self.default_config), 0.2397)
-        self.assertEqual(taxes_income.get_marginal_tax_rate(58596, self.default_config), 0.42)
-        self.assertEqual(taxes_income.get_marginal_tax_rate(58597, self.default_config), 0.42)
-        self.assertEqual(taxes_income.get_marginal_tax_rate(100000, self.default_config), 0.42)
-        self.assertEqual(taxes_income.get_marginal_tax_rate(277826, self.default_config), 0.45)
-        self.assertEqual(taxes_income.get_marginal_tax_rate(277827, self.default_config), 0.45)
+@pytest.mark.parametrize("taxable_income,expected_rate", [
+    (-1000, 0),
+    (0, 0),
+    (10346, 0),
+    (10347, 0.14),
+    (14926, 0.2397),
+    (58596, 0.42),
+    (58597, 0.42),
+    (100000, 0.42),
+    (277826, 0.45),
+    (277827, 0.45),
+])
+def test_get_marginal_tax_rate(taxable_income, expected_rate, default_config):
+    """Test marginal tax rate calculation for various income levels"""
+    result = taxes_income.get_marginal_tax_rate(taxable_income, default_config)
+    assert result == expected_rate
 
-    def test_valid_get_marginal_tax_rate_married(self):
-        config = TaxConfig(is_married=True)
-        self.assertEqual(taxes_income.get_marginal_tax_rate(10346, config), 0)
-        self.assertEqual(taxes_income.get_marginal_tax_rate(10347, config), 0)
-        self.assertEqual(taxes_income.get_marginal_tax_rate(10346 * 2, config), 0)
-        self.assertEqual(taxes_income.get_marginal_tax_rate(10347 * 2, config), 0.14)
 
-    def test_sameness_of_calc_income_tax_methods(self):
-        self.assertAlmostEqual(
-            taxes_income.calc_income_tax(12000, self.default_config),
-            taxes_income.calc_income_tax_by_integration(12000, self.default_config),
-            delta=0.1,
-        )
-        for taxable_income in range(0, 100001, 10000):
-            self.assertAlmostEqual(
-                taxes_income.calc_income_tax(taxable_income, self.default_config),
-                taxes_income.calc_income_tax_by_integration(taxable_income, self.default_config),
-                delta=0.1,
-            )
-        self.assertAlmostEqual(
-            taxes_income.calc_income_tax(300000, self.default_config),
-            taxes_income.calc_income_tax_by_integration(300000, self.default_config),
-            delta=0.1,
-        )
+@pytest.mark.parametrize("taxable_income,expected_rate", [
+    (10346, 0),
+    (10347, 0),
+    (10346 * 2, 0),
+    (10347 * 2, 0.14),
+])
+def test_get_marginal_tax_rate_married(taxable_income, expected_rate):
+    """Test marginal tax rate for married couples (doubled brackets)"""
+    config = TaxConfig(is_married=True)
+    result = taxes_income.get_marginal_tax_rate(taxable_income, config)
+    assert result == expected_rate
+
+
+@pytest.mark.parametrize("taxable_income", [
+    12000,
+    0, 10000, 20000, 30000, 40000, 50000, 60000, 70000, 80000, 90000, 100000,
+    300000,
+])
+def test_sameness_of_calc_income_tax_methods(taxable_income, default_config):
+    """Test that both income tax calculation methods give similar results"""
+    result_direct = taxes_income.calc_income_tax(taxable_income, default_config)
+    result_integration = taxes_income.calc_income_tax_by_integration(taxable_income, default_config)
+    assert abs(result_direct - result_integration) < 0.1
+
+
+def test_get_marginal_tax_rate_with_default_none_config():
+    """Test that get_marginal_tax_rate works when config=None"""
+    result = taxes_income.get_marginal_tax_rate(50000)
+    assert isinstance(result, float)
+    assert 0 <= result <= 1
+
+
+def test_calc_income_tax_with_default_none_config():
+    """Test that calc_income_tax works when config=None"""
+    result = taxes_income.calc_income_tax(50000)
+    assert isinstance(result, float)
+    assert result >= 0
+
+
+def test_calc_income_tax_by_integration_with_default_none_config():
+    """Test that calc_income_tax_by_integration works when config=None"""
+    result = taxes_income.calc_income_tax_by_integration(50000)
+    assert isinstance(result, float)
+    assert result >= 0

--- a/test/test_taxes_other.py
+++ b/test/test_taxes_other.py
@@ -1,31 +1,62 @@
-import unittest
+import pytest
 
 from netto.config import TaxConfig
 import netto.taxes_other as taxes_other
 
 
-class TestTaxesOther(unittest.TestCase):
-    def setUp(self):
-        # Create default config for tests
-        self.default_config = TaxConfig(
-            extra_health_insurance=0.014,
-            church_tax=0.09,
-            has_children=False
-        )
+@pytest.fixture
+def default_config():
+    """Fixture providing default config for tests"""
+    return TaxConfig(
+        extra_health_insurance=0.014,
+        church_tax=0.09,
+        has_children=False
+    )
 
-    def tearDown(self):
-        pass
 
-    def test_valid_calc_soli(self):
-        self.assertEqual(taxes_other.calc_soli(-1000, self.default_config), 0)
-        self.assertEqual(taxes_other.calc_soli(0, self.default_config), 0)
-        self.assertEqual(taxes_other.calc_soli(16956, self.default_config), 0)
-        self.assertAlmostEqual(taxes_other.calc_soli(16957, self.default_config), 0.119, delta=0.1)
-        self.assertAlmostEqual(taxes_other.calc_soli(17514.96, self.default_config), 66.48, delta=0.1)
-        self.assertAlmostEqual(taxes_other.calc_soli(26913.96, self.default_config), 1185.0, delta=0.1)
-        self.assertEqual(taxes_other.calc_soli(100000, self.default_config), 5500)
+@pytest.mark.parametrize("income_tax,expected", [
+    (-1000, 0),
+    (0, 0),
+    (16956, 0),
+    (100000, 5500),
+])
+def test_calc_soli_exact(income_tax, expected, default_config):
+    """Test solidarity tax calculation with exact values"""
+    result = taxes_other.calc_soli(income_tax, default_config)
+    assert result == expected
 
-    def test_valid_calc_church_tax(self):
-        self.assertEqual(taxes_other.calc_church_tax(-1000, self.default_config), 0)
-        self.assertEqual(taxes_other.calc_church_tax(0, self.default_config), 0)
-        self.assertEqual(taxes_other.calc_church_tax(10000, self.default_config), 900)
+
+@pytest.mark.parametrize("income_tax,expected", [
+    (16957, 0.119),
+    (17514.96, 66.48),
+    (26913.96, 1185.0),
+])
+def test_calc_soli_approximate(income_tax, expected, default_config):
+    """Test solidarity tax calculation with approximate values"""
+    result = taxes_other.calc_soli(income_tax, default_config)
+    assert abs(result - expected) < 0.1
+
+
+@pytest.mark.parametrize("income_tax,expected", [
+    (-1000, 0),
+    (0, 0),
+    (10000, 900),
+])
+def test_calc_church_tax(income_tax, expected, default_config):
+    """Test church tax calculation"""
+    result = taxes_other.calc_church_tax(income_tax, default_config)
+    assert result == expected
+
+
+def test_calc_soli_with_default_none_config():
+    """Test that calc_soli works when config=None"""
+    result = taxes_other.calc_soli(10000)
+    assert isinstance(result, float)
+    assert result >= 0
+
+
+def test_calc_church_tax_with_default_none_config():
+    """Test that calc_church_tax works when config=None"""
+    result = taxes_other.calc_church_tax(10000)
+    assert isinstance(result, float)
+    assert result >= 0


### PR DESCRIPTION
This PR prepares the second alpha release of v0.2.0 with a complete migration from unittest to pytest and significantly improved test coverage, particularly for the data_loader module and config=None default paths.

Test Framework Migration (unittest → pytest)
